### PR TITLE
upgrade guava to 29.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>13.0.1</version>
+      <version>29.0-jre</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>


### PR DESCRIPTION
Upgrades guava in response to [GHSA-mvr2-9pj6-7w5j ](https://github.com/advisories/GHSA-mvr2-9pj6-7w5j).